### PR TITLE
Run command only lets the original user interact through reactions.

### DIFF
--- a/src/Commands/DocsCommand.ts
+++ b/src/Commands/DocsCommand.ts
@@ -84,11 +84,11 @@ export class DocsCommand extends CommandBase {
 
                 if (result[ 0 ].key === matches[ 2 ]) {
 
-                    DocsCommand.sendDoc(command, result[ 0 ], currentPage, matches[ 1 ]);
+                    DocsCommand.sendDoc(command, result[ 0 ], currentPage, matches[ 1 ], command.obj.author.id);
 
                 } else {
 
-                    DocsCommand.sendResults(command, result, matches);
+                    DocsCommand.sendResults(command, result, matches, command.obj.author.id);
 
                 }
 
@@ -114,9 +114,11 @@ export class DocsCommand extends CommandBase {
      * @param result Document to send
      * @param currentPage Index representation of location the document
      * @param matches Language and term names
+     * @param originID ID for who sent the command message
      * @param message? If a message has already been sent, pass it here to overwrite instead
+     *
      */
-    public static async sendDoc(command: CommandParser, result: Doc, currentPage: number, matches: string, message?: any) {
+    public static async sendDoc(command: CommandParser, result: Doc, currentPage: number, matches: string, originID: string, message?: any) {
 
         let messagePassed: boolean;
 
@@ -147,7 +149,7 @@ export class DocsCommand extends CommandBase {
         // @ts-ignore
         collector.on('collect', async (reaction, collector) => {
 
-            if (reaction.users.size === 2 && reaction.me) {
+            if (reaction.users.size >= 2 && reaction.me) {
 
                 if (reaction.emoji.name === '🔽') {
 
@@ -166,8 +168,8 @@ export class DocsCommand extends CommandBase {
                     }
 
                     DocsCommand.addReactions(message, currentPage > 0, currentPage < result.pages);
-                    
-                } else if (reaction.emoji.name === '🗑' && !messagePassed) {
+
+                } else if (reaction.users.has(originID) && reaction.emoji.name === '🗑' && !messagePassed) {
 
                     if (reaction.me) {
 
@@ -187,11 +189,12 @@ export class DocsCommand extends CommandBase {
      * Sends results from search, with emojis to choose which document
      *
      * @param command Parsed out command
-     * @param result Document to send
+     * @param results Document to send
      * @param matches Language and term names
+     * @param originID ID for who sent the command message
      *
      */
-    public static async sendResults(command: CommandParser, results: Doc[], matches: string[]) {
+    public static async sendResults(command: CommandParser, results: Doc[], matches: string[], originID: string) {
 
         const emojiNumbers = [ '1⃣', '2⃣', '3⃣', '4⃣', '5⃣', '6⃣', '7⃣', '8⃣', '9⃣', '🔟' ].slice(0, results.length);
 
@@ -236,7 +239,7 @@ export class DocsCommand extends CommandBase {
         // @ts-ignore
         collector.on('collect', async (reaction, collector) => {
 
-            if (reaction.users.size === 2 && reaction.me) {
+            if (reaction.users.has(originID) && reaction.users.size >= 2 && reaction.me) {
 
                 // @ts-ignore
                 if (reaction.emoji.name === '🗑') {
@@ -245,7 +248,7 @@ export class DocsCommand extends CommandBase {
 
                 } else {
 
-                    DocsCommand.sendDoc(command, results[emojiNumbers.indexOf(reaction.emoji.name)], 0, matches[1], message);
+                    DocsCommand.sendDoc(command, results[emojiNumbers.indexOf(reaction.emoji.name)], 0, matches[1], originID, message);
 
                 }
 

--- a/src/Commands/DocsCommand.ts
+++ b/src/Commands/DocsCommand.ts
@@ -165,8 +165,8 @@ export class DocsCommand extends CommandBase {
 
                     }
 
-                    DocsCommand.addReactions(message, currentPage > 0, (currentPage + 1) < result.pages);
-
+                    DocsCommand.addReactions(message, currentPage > 0, currentPage < result.pages);
+                    
                 } else if (reaction.emoji.name === '🗑' && !messagePassed) {
 
                     if (reaction.me) {

--- a/src/Commands/DocsCommand.ts
+++ b/src/Commands/DocsCommand.ts
@@ -118,10 +118,18 @@ export class DocsCommand extends CommandBase {
      */
     public static async sendDoc(command: CommandParser, result: Doc, currentPage: number, matches: string, message?: any) {
 
+        let messagePassed: boolean;
+
         if (message) {
+
             message = await message.edit(DocsCommand.getEmbed(result, currentPage, matches));
+            messagePassed = true;
+
         } else {
+
             message = await command.obj.channel.send(DocsCommand.getEmbed(result, currentPage, matches));
+            messagePassed = false;
+
         }
 
         const filter = (reaction: any, user: any) => {
@@ -159,7 +167,7 @@ export class DocsCommand extends CommandBase {
 
                     DocsCommand.addReactions(message, currentPage > 0, (currentPage + 1) < result.pages);
 
-                } else if (reaction.emoji.name === '🗑') {
+                } else if (reaction.emoji.name === '🗑' && !messagePassed) {
 
                     if (reaction.me) {
 


### PR DESCRIPTION
Exception: page reactions are allowed for anyone with docsbot role. 

Also fixed two bugs:
- Error when deleting message was being caused by the 'trash' emoji having two listeners and would be deleted twice. This happens when the search dialogue happens, and then the document is brought up.
- For a document with only two pages (ex: `;javascript ok`) selecting next then previous would cause the previous arrow to not show up again.  